### PR TITLE
COMP: Use vtkMRMLLabelMapVolumeNode

### DIFF
--- a/Loadable/RegionType/MyRegionType/MRML/vtkMRMLMyRegionTypeNode.cxx
+++ b/Loadable/RegionType/MyRegionType/MRML/vtkMRMLMyRegionTypeNode.cxx
@@ -39,7 +39,6 @@ vtkMRMLNodeNewMacro(vtkMRMLMyRegionTypeNode);
 //-----------------------------------------------------------------------------
 vtkMRMLMyRegionTypeNode::vtkMRMLMyRegionTypeNode()
 {
-  this->SetAttribute("LabelMap", "1");
   /*this->RegionValuesList = NULL;
   this->RegionNamesList = NULL;
   this->TypeValuesList = NULL;

--- a/Loadable/RegionType/MyRegionType/MRML/vtkMRMLMyRegionTypeNode.h
+++ b/Loadable/RegionType/MyRegionType/MRML/vtkMRMLMyRegionTypeNode.h
@@ -22,7 +22,7 @@
 #ifndef __vtkMRMLMyRegionTypeNode_h
 #define __vtkMRMLMyRegionTypeNode_h
 
-#include "vtkMRMLScalarVolumeNode.h"
+#include "vtkMRMLLabelMapVolumeNode.h"
 #include "vtkSlicerMyRegionTypeModuleMRMLExport.h"
 
 // STD includes
@@ -32,11 +32,11 @@
 class vtkMRMLStorageNode; 
 class vtkMRMLColorNode;
 
-class VTK_SLICER_MYREGIONTYPE_MODULE_MRML_EXPORT vtkMRMLMyRegionTypeNode : public vtkMRMLScalarVolumeNode
+class VTK_SLICER_MYREGIONTYPE_MODULE_MRML_EXPORT vtkMRMLMyRegionTypeNode : public vtkMRMLLabelMapVolumeNode
 {
 public:
   static vtkMRMLMyRegionTypeNode *New();
-  vtkTypeMacro(vtkMRMLMyRegionTypeNode,vtkMRMLScalarVolumeNode);
+  vtkTypeMacro(vtkMRMLMyRegionTypeNode,vtkMRMLLabelMapVolumeNode);
   void PrintSelf(ostream& os, vtkIndent indent);
 
   //--------------------------------------------------------------------------

--- a/Loadable/RegionType/MyRegionType/qSlicerMyRegionTypeModuleWidget.cxx
+++ b/Loadable/RegionType/MyRegionType/qSlicerMyRegionTypeModuleWidget.cxx
@@ -31,7 +31,7 @@
 #include <vtkMRMLScene.h>
 #include <vtkMRMLMyRegionTypeNode.h>
 #include <vtkMRMLMyRegionTypeDisplayNode.h>
-#include <vtkMRMLScalarVolumeNode.h>
+#include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLLabelMapVolumeDisplayNode.h>
 #include <vtkMRMLChestRTColorTableNode.h>
 
@@ -155,13 +155,13 @@ void qSlicerMyRegionTypeModuleWidget::setMRMLScene(vtkMRMLScene* scene)
 //-----------------------------------------------------------------------------
 void qSlicerMyRegionTypeModuleWidget::initializeRegionTypeNode(vtkMRMLScene* scene)
 {
-  vtkCollection* regionTypeNodes = scene->GetNodesByClass("vtkMRMLScalarVolumeNode");
+  vtkCollection* regionTypeNodes = scene->GetNodesByClass("vtkMRMLLabelMapVolumeNode");
 std::cout<<"in initializeRegionTypeNode"<<std::endl;
   if( regionTypeNodes->GetNumberOfItems() > 0 )
   {
-	vtkMRMLScalarVolumeNode* scalarNode = vtkMRMLScalarVolumeNode::SafeDownCast( regionTypeNodes->GetItemAsObject(0) );
+	vtkMRMLLabelMapVolumeNode* scalarNode = vtkMRMLLabelMapVolumeNode::SafeDownCast( regionTypeNodes->GetItemAsObject(0) );
 	this->regionTypeNode = vtkMRMLMyRegionTypeNode::New();
-	if( scalarNode->GetLabelMap() )
+	if( scalarNode )
 	{
 		this->regionTypeNode->CopyWithScene(scalarNode);
 		scene->AddNode(this->regionTypeNode);
@@ -239,20 +239,20 @@ void qSlicerMyRegionTypeModuleWidget::onInputVolumeChanged()
           logic->DisplayAllRegionType( this->regionTypeNode );
 		  this->updateWidget();
 	  }
-	  else if( node->IsA( "vtkMRMLScalarVolumeNode" ) && d->InputVolumeComboBox->nodes().count() > 1)
+	  else if( node->IsA( "vtkMRMLLabelMapVolumeNode" ) && d->InputVolumeComboBox->nodes().count() > 1)
 	  {
           d->TypeLabelsComboBox->clear();
   		  d->RegionLabelsComboBox->clear();
-		  vtkMRMLScalarVolumeNode* scalarNode = vtkMRMLScalarVolumeNode::SafeDownCast( node );
-		  if( scalarNode->GetLabelMap() )
+		  vtkMRMLLabelMapVolumeNode* scalarNode = vtkMRMLLabelMapVolumeNode::SafeDownCast( node );
+		  if( scalarNode )
 		  {
 			  this->convertToRegionTypeNode(scalarNode);
 		  }
 	  }
-	  else if( d->InputVolumeComboBox->nodes().count() == 1 && this->initialize == 0 && node->IsA( "vtkMRMLScalarVolumeNode" ) )
+	  else if( d->InputVolumeComboBox->nodes().count() == 1 && this->initialize == 0 && node->IsA( "vtkMRMLLabelMapVolumeNode" ) )
 	 {
-		vtkMRMLScalarVolumeNode* scalarNode = vtkMRMLScalarVolumeNode::SafeDownCast( node );
-		if( scalarNode->GetLabelMap() )
+		vtkMRMLLabelMapVolumeNode* scalarNode = vtkMRMLLabelMapVolumeNode::SafeDownCast( node );
+		if( scalarNode )
 		{
 			if( node->IsA( "vtkMRMLMyRegionTypeNode" ) )
 			{
@@ -272,7 +272,7 @@ void qSlicerMyRegionTypeModuleWidget::onInputVolumeChanged()
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerMyRegionTypeModuleWidget::convertToRegionTypeNode(vtkMRMLScalarVolumeNode* scalarVolume)
+void qSlicerMyRegionTypeModuleWidget::convertToRegionTypeNode(vtkMRMLLabelMapVolumeNode* scalarVolume)
 {
 	std::cout<<"in convertToRegionTypeNode"<<std::endl;
     this->regionTypeNode = vtkMRMLMyRegionTypeNode::New();

--- a/Loadable/RegionType/MyRegionType/qSlicerMyRegionTypeModuleWidget.h
+++ b/Loadable/RegionType/MyRegionType/qSlicerMyRegionTypeModuleWidget.h
@@ -23,7 +23,7 @@
 
 #include "qSlicerMyRegionTypeModuleExport.h"
 #include <vtkNew.h>
-#include <vtkMRMLScalarVolumeNode.h>
+#include <vtkMRMLLabelMapVolumeNode.h>
 
 class qSlicerMyRegionTypeModuleWidgetPrivate;
 class vtkMRMLNode;
@@ -51,7 +51,7 @@ protected:
   virtual void setMRMLScene(vtkMRMLScene*);
 
   void initializeRegionTypeNode(vtkMRMLScene*);
-  void convertToRegionTypeNode(vtkMRMLScalarVolumeNode*);
+  void convertToRegionTypeNode(vtkMRMLLabelMapVolumeNode*);
 
 protected slots:
   void onInputVolumeChanged();

--- a/Loadable/RegionTypeDisplay/MRML/vtkMRMLRegionTypeNode.cxx
+++ b/Loadable/RegionTypeDisplay/MRML/vtkMRMLRegionTypeNode.cxx
@@ -45,7 +45,6 @@ vtkMRMLNodeNewMacro(vtkMRMLRegionTypeNode);
 //-----------------------------------------------------------------------------
 vtkMRMLRegionTypeNode::vtkMRMLRegionTypeNode()
 {
-  this->SetAttribute("LabelMap", "1");
 }
 
 //-----------------------------------------------------------------------------

--- a/Loadable/RegionTypeDisplay/MRML/vtkMRMLRegionTypeNode.h
+++ b/Loadable/RegionTypeDisplay/MRML/vtkMRMLRegionTypeNode.h
@@ -22,7 +22,7 @@
 #ifndef __vtkMRMLRegionTypeNode_h
 #define __vtkMRMLRegionTypeNode_h
 
-#include "vtkMRMLScalarVolumeNode.h"
+#include "vtkMRMLLabelMapVolumeNode.h"
 #include "vtkSlicerRegionTypeModuleMRMLExport.h"
 
 // STD includes
@@ -34,11 +34,11 @@ class vtkMRMLStorageNode;
 class vtkMRMLColorNode;
 class vtkMRMLRegionTypeDisplayNode;
 
-class VTK_SLICER_REGIONTYPE_MODULE_MRML_EXPORT vtkMRMLRegionTypeNode : public vtkMRMLScalarVolumeNode
+class VTK_SLICER_REGIONTYPE_MODULE_MRML_EXPORT vtkMRMLRegionTypeNode : public vtkMRMLLabelMapVolumeNode
 {
 public:
   static vtkMRMLRegionTypeNode *New();
-  vtkTypeMacro(vtkMRMLRegionTypeNode,vtkMRMLScalarVolumeNode);
+  vtkTypeMacro(vtkMRMLRegionTypeNode,vtkMRMLLabelMapVolumeNode);
   void PrintSelf(ostream& os, vtkIndent indent);
 
   //--------------------------------------------------------------------------

--- a/Scripted/EmphysemaSubtypes/EmphysemaSubtypes.py
+++ b/Scripted/EmphysemaSubtypes/EmphysemaSubtypes.py
@@ -56,7 +56,6 @@ class EmphysemaSubtypesWidget:
 
     self.grayscaleSelector = slicer.qMRMLNodeComboBox(self.grayscaleSelectorFrame)
     self.grayscaleSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.grayscaleSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.grayscaleSelector.selectNodeUponCreation = False
     self.grayscaleSelector.addEnabled = False
     self.grayscaleSelector.removeEnabled = False
@@ -80,8 +79,7 @@ class EmphysemaSubtypesWidget:
     self.labelSelectorFrame.layout().addWidget( self.labelSelectorLabel )
 
     self.labelSelector = slicer.qMRMLNodeComboBox()
-    self.labelSelector.nodeTypes = ( "vtkMRMLScalarVolumeNode", "" )
-    self.labelSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", "1" )
+    self.labelSelector.nodeTypes = ( "vtkMRMLLabelMapVolumeNode", "" )
     # todo addAttribute
     self.labelSelector.selectNodeUponCreation = False
     self.labelSelector.addEnabled = False

--- a/Scripted/Example/Example.py
+++ b/Scripted/Example/Example.py
@@ -95,7 +95,6 @@ class SlicerCIPExampleWidget:
     #
     self.inputSelector = slicer.qMRMLNodeComboBox()
     self.inputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.inputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.inputSelector.selectNodeUponCreation = True
     self.inputSelector.addEnabled = False
     self.inputSelector.removeEnabled = False
@@ -111,7 +110,6 @@ class SlicerCIPExampleWidget:
     #
     self.outputSelector = slicer.qMRMLNodeComboBox()
     self.outputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.outputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.outputSelector.selectNodeUponCreation = False
     self.outputSelector.addEnabled = True
     self.outputSelector.removeEnabled = True

--- a/Scripted/InteractiveLobeSegmentation/InteractiveLobeSegmentation.py
+++ b/Scripted/InteractiveLobeSegmentation/InteractiveLobeSegmentation.py
@@ -100,8 +100,7 @@ class InteractiveLobeSegmentationWidget:
     #
 
     self.inputSelector1 = slicer.qMRMLNodeComboBox()
-    self.inputSelector1.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.inputSelector1.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 1 )
+    self.inputSelector1.nodeTypes = ( ("vtkMRMLLabelMapVolumeNode"), "" )
     self.inputSelector1.selectNodeUponCreation = True
     self.inputSelector1.addEnabled = False
     self.inputSelector1.removeEnabled = False
@@ -116,8 +115,7 @@ class InteractiveLobeSegmentationWidget:
     #
 
     self.outputSelector = slicer.qMRMLNodeComboBox()
-    self.outputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.outputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 1 )
+    self.outputSelector.nodeTypes = ( ("vtkMRMLLabelMapVolumeNode"), "" )
     self.outputSelector.selectNodeUponCreation = True
     self.outputSelector.addEnabled = True
     self.outputSelector.removeEnabled = True

--- a/Scripted/LungRegistration/LungRegistration.py
+++ b/Scripted/LungRegistration/LungRegistration.py
@@ -106,7 +106,6 @@ class LungRegistrationWidget:
     #input CT image selector
     self.inputSelector = slicer.qMRMLNodeComboBox()
     self.inputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    #self.inputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.inputSelector.selectNodeUponCreation = True
     self.inputSelector.addEnabled = False
     self.inputSelector.removeEnabled = False
@@ -123,7 +122,7 @@ class LungRegistrationWidget:
     ##
     self.atlasSelector = slicer.qMRMLNodeComboBox()
     self.atlasSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    #self.leftAtlasSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 1 )
+    #self.atlasSelector.nodeTypes = ( ("vtkMRMLLabelMapVolumeNode"), "" )
     self.atlasSelector.selectNodeUponCreation = True
     self.atlasSelector.addEnabled = False
     self.atlasSelector.removeEnabled = False
@@ -139,7 +138,7 @@ class LungRegistrationWidget:
     ##
     #self.rightAtlasSelector = slicer.qMRMLNodeComboBox()
     #self.rightAtlasSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    ##self.rightAtlasSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 2 )
+    ##self.rightAtlasSelector.nodeTypes = ( ("vtkMRMLLabelMapVolumeNode"), "" )
     #self.rightAtlasSelector.selectNodeUponCreation = True
     #self.rightAtlasSelector.addEnabled = False
     #self.rightAtlasSelector.removeEnabled = False
@@ -158,7 +157,6 @@ class LungRegistrationWidget:
     #
     self.outputSelector = slicer.qMRMLNodeComboBox()
     self.outputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.outputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.outputSelector.selectNodeUponCreation = False
     self.outputSelector.addEnabled = True
     self.outputSelector.removeEnabled = True

--- a/Scripted/ParenchymaAnalysis/ParenchymaAnalysis.py
+++ b/Scripted/ParenchymaAnalysis/ParenchymaAnalysis.py
@@ -88,7 +88,6 @@ class ParenchymaAnalysisWidget:
 
     self.inspSelector = slicer.qMRMLNodeComboBox(self.inspSelectorFrame)
     self.inspSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.inspSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.inspSelector.selectNodeUponCreation = False
     self.inspSelector.addEnabled = False
     self.inspSelector.removeEnabled = False
@@ -114,7 +113,6 @@ class ParenchymaAnalysisWidget:
     
     self.expSelector = slicer.qMRMLNodeComboBox(self.expSelectorFrame)
     self.expSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.expSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.expSelector.selectNodeUponCreation = False
     self.expSelector.addEnabled = False
     self.expSelector.removeEnabled = False
@@ -139,8 +137,7 @@ class ParenchymaAnalysisWidget:
     self.insplabelSelectorFrame.layout().addWidget( self.insplabelSelectorLabel )
 
     self.insplabelSelector = slicer.qMRMLNodeComboBox()
-    self.insplabelSelector.nodeTypes = ( "vtkMRMLScalarVolumeNode", "" )
-    self.insplabelSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", "1" )
+    self.insplabelSelector.nodeTypes = ( "vtkMRMLLabelMapVolumeNode", "" )
     # todo addAttribute
     self.insplabelSelector.selectNodeUponCreation = False
     self.insplabelSelector.addEnabled = False
@@ -164,8 +161,7 @@ class ParenchymaAnalysisWidget:
     self.explabelSelectorFrame.layout().addWidget( self.explabelSelectorLabel )
     
     self.explabelSelector = slicer.qMRMLNodeComboBox()
-    self.explabelSelector.nodeTypes = ( "vtkMRMLScalarVolumeNode", "" )
-    self.explabelSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", "1" )
+    self.explabelSelector.nodeTypes = ( "vtkMRMLLabelMapVolumeNode", "" )
     # todo addAttribute
     self.explabelSelector.selectNodeUponCreation = False
     self.explabelSelector.addEnabled = False

--- a/Scripted/PectoralisSegmentation/PectoralisSegmentation.py
+++ b/Scripted/PectoralisSegmentation/PectoralisSegmentation.py
@@ -110,7 +110,6 @@ class PectoralisSegmentationWidget:
     #
     self.outputSelector = slicer.qMRMLNodeComboBox()
     self.outputSelector.nodeTypes = ( ("vtkMRMLScalarVolumeNode"), "" )
-    self.outputSelector.addAttribute( "vtkMRMLScalarVolumeNode", "LabelMap", 0 )
     self.outputSelector.selectNodeUponCreation = False
     self.outputSelector.addEnabled = True
     self.outputSelector.removeEnabled = True


### PR DESCRIPTION
A new class for labelmap nodes (vtkMRMLLabelmapNode) was introduced into the Slicer core
that replaces the old method of storing segmentation in a vtkMRMLScalarVolumeNode with
a custom “labelmap” attribute set to "1".
See details here:
http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/Segmentations#vtkMRMLLabelMapVolumeNode_integration

This change in the Slicer core requires modification of your extension. See the suggested change in this commit.
