### PR TITLE
COMP: Fix "‘itksys_stl’ does not name a type" compile error.

### DIFF
--- a/Loadable/AirwayModule/Logic/vtkSlicerAirwayModuleLogic.cxx
+++ b/Loadable/AirwayModule/Logic/vtkSlicerAirwayModuleLogic.cxx
@@ -168,8 +168,8 @@ vtkMRMLAirwayNode* vtkSlicerAirwayModuleLogic::AddAirway (const char* filename)
   storageNode->SetFileName(filename);
   if (storageNode->ReadData(airwayNode) != 0)
     {
-    const itksys_stl::string fname(filename);
-    itksys_stl::string name = itksys::SystemTools::GetFilenameWithoutExtension(fname);
+    const std::string fname(filename);
+    std::string name = itksys::SystemTools::GetFilenameWithoutExtension(fname);
     std::string uname( this->GetMRMLScene()->GetUniqueNameByString(name.c_str()));
     airwayNode->SetName(uname.c_str());
    

--- a/Loadable/ParticlesDisplay/Logic/vtkSlicerParticlesDisplayLogic.cxx
+++ b/Loadable/ParticlesDisplay/Logic/vtkSlicerParticlesDisplayLogic.cxx
@@ -132,8 +132,8 @@ vtkMRMLParticlesNode* vtkSlicerParticlesDisplayLogic::AddParticlesNode (const ch
   storageNode->SetFileName(filename);
   if (storageNode->ReadData(particlesNode) != 0)
     {
-    const itksys_stl::string fname(filename);
-    itksys_stl::string name = itksys::SystemTools::GetFilenameWithoutExtension(fname);
+    const std::string fname(filename);
+    std::string name = itksys::SystemTools::GetFilenameWithoutExtension(fname);
     std::string uname( this->GetMRMLScene()->GetUniqueNameByString(name.c_str()));
     particlesNode->SetName(uname.c_str());
 


### PR DESCRIPTION
This updates code to be independent of KWSys function signature changes
introduced in InsightSoftwareConsortium/ITK@d584693 (ENH: Remove use of
include <itksys/stl/*> and itksys_stl::*) following Slicer r24836 (ENH:
Update ITKv4 to v4.9.0 release branch)

It fixes the following build errors:

/home/jcfr/Projects/SlicerCIP/Loadable/ParticlesDisplay/Logic/vtkSlicerParticlesDisplayLogic.cxx:135:11: error: ‘itksys_stl’ does not name a type
     const itksys_stl::string fname(filename);
           ^
/home/jcfr/Projects/SlicerCIP/Loadable/ParticlesDisplay/Logic/vtkSlicerParticlesDisplayLogic.cxx:136:5: error: ‘itksys_stl’ has not been declared
     itksys_stl::string name = itksys::SystemTools::GetFilenameWithoutExtension(fname);
     ^
/home/jcfr/Projects/SlicerCIP/Loadable/ParticlesDisplay/Logic/vtkSlicerParticlesDisplayLogic.cxx:137:68: error: ‘name’ was not declared in this scope
     std::string uname( this->GetMRMLScene()->GetUniqueNameByString(name.c_str()));
                                                                    ^
