### PR TITLE
BUG: Re-register TractographyDisplay DM only once. Fixes #6

### DIFF
--- a/Loadable/ParticlesDisplay/qSlicerParticlesDisplayModule.cxx
+++ b/Loadable/ParticlesDisplay/qSlicerParticlesDisplayModule.cxx
@@ -35,7 +35,6 @@
 #include "qSlicerParticlesDisplayModuleWidget.h"
 #include "qSlicerParticlesReader.h"
 
-#include <vtkMRMLThreeDViewDisplayableManagerFactory.h>
 //-----------------------------------------------------------------------------
 Q_EXPORT_PLUGIN2(qSlicerParticlesDisplayModule, qSlicerParticlesDisplayModule);
 
@@ -107,16 +106,13 @@ QStringList qSlicerParticlesDisplayModule::categories() const
 //-----------------------------------------------------------------------------
 QStringList qSlicerParticlesDisplayModule::dependencies() const
 {
-  return QStringList() << "RegionType";
+  return QStringList() << "RegionType" << "TractographyDisplay";
 }
 
 //-----------------------------------------------------------------------------
 void qSlicerParticlesDisplayModule::setup()
 {
   this->Superclass::setup();
-
-  vtkMRMLThreeDViewDisplayableManagerFactory::GetInstance()->
-    RegisterDisplayableManager("vtkMRMLTractographyDisplayDisplayableManager");
 
   vtkSlicerParticlesDisplayLogic* particlesDisplayLogic =
     vtkSlicerParticlesDisplayLogic::SafeDownCast(this->logic());


### PR DESCRIPTION
Removes registration of the displayable manager and instead add a dependency
to "TractographyDisplay" module. This ensures the displayable manager
is registered before loading "ParticlesDisplay" module.
