### PR TITLE
COMP: more compile warning fixes

### DIFF
--- a/Loadable/ParticlesDisplay/Logic/vtkSlicerParticlesDisplayLogic.cxx
+++ b/Loadable/ParticlesDisplay/Logic/vtkSlicerParticlesDisplayLogic.cxx
@@ -124,7 +124,7 @@ vtkMRMLParticlesNode* vtkSlicerParticlesDisplayLogic::AddParticlesNode (const ch
   vtkNew<vtkMRMLModelStorageNode> storageNode;
 
   storageNode->SetFileName(filename);
-  if (!storageNode->ReadData(particlesNode.GetPointer()) != 0)
+  if (storageNode->ReadData(particlesNode.GetPointer()) != 0)
     {
     const std::string fname(filename);
     std::string name = itksys::SystemTools::GetFilenameWithoutExtension(fname);

--- a/Loadable/ParticlesDisplay/qSlicerParticlesDisplayModule.h
+++ b/Loadable/ParticlesDisplay/qSlicerParticlesDisplayModule.h
@@ -44,25 +44,25 @@ public:
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 
-  virtual QString helpText()const;
-  virtual QString acknowledgementText()const;
-  virtual QStringList contributors()const;
+  virtual QString helpText()const override;
+  virtual QString acknowledgementText()const override;
+  virtual QStringList contributors()const override;
 
-  virtual QIcon icon()const;
+  virtual QIcon icon()const override;
 
-  virtual QStringList categories()const;
-  virtual QStringList dependencies() const;
+  virtual QStringList categories()const override;
+  virtual QStringList dependencies() const override;
 
 protected:
 
   /// Initialize the module. Register the volumes reader/writer
-  virtual void setup();
+  virtual void setup() override;
 
   /// Create and return the widget representation associated to this module
-  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation();
+  virtual qSlicerAbstractModuleRepresentation * createWidgetRepresentation() override;
 
   /// Create and return the logic associated to this module
-  virtual vtkMRMLAbstractLogic* createLogic();
+  virtual vtkMRMLAbstractLogic* createLogic() override;
 
 protected:
   QScopedPointer<qSlicerParticlesDisplayModulePrivate> d_ptr;


### PR DESCRIPTION
Note that this change appears to change the logic:

-  if (!storageNode->ReadData(particlesNode.GetPointer()) != 0)
+  if (storageNode->ReadData(particlesNode.GetPointer()) != 0)

I believe the old code was actually incorrect (not sure if it
actually worked).  ReadData returns 0 on error, so with this
change the code that uses the data is only executed when ReadData
succeeds.