### PR TITLE
Fix relative path import error (BodyComposition)

### DIFF
--- a/Scripted/CIP_BodyComposition/CIP_BodyComposition.py
+++ b/Scripted/CIP_BodyComposition/CIP_BodyComposition.py
@@ -15,7 +15,7 @@ from slicer.ScriptedLoadableModule import *
 
 from CIP.logic.SlicerUtil import SlicerUtil
 from CIP.logic import Util
-from .CIP_BodyComposition_logic import BodyCompositionParameters
+from CIP_BodyComposition_logic import BodyCompositionParameters
 from CIP.ui import CaseReportsWidget
 import CIP.ui as CIPUI
 


### PR DESCRIPTION
Without this change the import error reported below
occurs on mac installation.

With this change things work as expected.

I believe the no-dot version is correct and the
dot is not needed in this scenario.

```
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) - Traceback (most recent call last):
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) -   File "<string>", line 1, in <module>
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) -   File "/Applications/Slicer 3.app/Contents/lib/Python/lib/python3.6/imp.py", line 170, in load_source
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) -     module = _exec(spec, sys.modules[name])
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) -   File "<frozen importlib._bootstrap>", line 618, in _exec
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) -   File "<frozen importlib._bootstrap_external>", line 678, in exec_module
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) -   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) -   File "/Applications/Slicer 3.app/Contents/Extensions-29253/Chest_Imaging_Platform/lib/Slicer-4.11/qt-scripted-modules/CIP_BodyComposition.py", line 18, in <module>
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) -     from .CIP_BodyComposition_logic import BodyCompositionParameters
[CRITICAL][Stream] 06.08.2020 14:48:02 [] (unknown:0) - ImportError: attempted relative import with no known parent package
[CRITICAL][Qt] 06.08.2020 14:48:02 [] (unknown:0) - loadSourceAsModule - Failed to load file "/Applications/Slicer 3.app/Contents/Extensions-29253/Chest_Imaging_Platform/lib/Slicer-4.11/qt-scripted-modules/CIP_BodyComposition.py"  as module "CIP_BodyComposition" !
[CRITICAL][Qt] 06.08.2020 14:48:02 [] (unknown:0) - Fail to instantiate module  "CIP_BodyComposition"
[CRITICAL][Qt] 06.08.2020 14:48:03 [] (unknown:0) - The following modules failed to be instantiated:
[CRITICAL][Qt] 06.08.2020 14:48:03 [] (unknown:0) -    CIP_BodyComposition
```