### PR TITLE
Update modules to match Slicer-4.11 API

### DIFF
--- a/Scripted/CIP_AVRatio/CIP_AVRatio.py
+++ b/Scripted/CIP_AVRatio/CIP_AVRatio.py
@@ -43,10 +43,6 @@ class CIP_AVRatioWidget(ScriptedLoadableModuleWidget):
     CORONAL = 8
 
     @property
-    def moduleName(self):
-        return os.path.basename(__file__).replace(".py", "")
-
-    @property
     def currentVolumeId(self):
         return self.volumeSelector.currentNodeID
 

--- a/Scripted/CIP_BodyComposition/CIP_BodyComposition.py
+++ b/Scripted/CIP_BodyComposition/CIP_BodyComposition.py
@@ -41,10 +41,6 @@ class CIP_BodyComposition(ScriptedLoadableModule):
 #######################################
 class CIP_BodyCompositionWidget(ScriptedLoadableModuleWidget):
     """GUI object"""
-    @property
-    def moduleName(self):
-        return os.path.basename(__file__).replace(".py", "")
-        # return "CIP_BodyComposition"
 
     __preventDialogs__ = False
     # @property

--- a/Scripted/CIP_Calibration/CIP_Calibration.py
+++ b/Scripted/CIP_Calibration/CIP_Calibration.py
@@ -52,10 +52,6 @@ class CIP_CalibrationWidget(ScriptedLoadableModuleWidget):
         self.pendingChangesIdsList = []
 
     @property
-    def moduleName(self):
-        return 'CIP_Calibration'
-
-    @property
     def labelmapNodeNameExtension(self):
         return "calibrationLabelMap"
 

--- a/Scripted/CIP_InteractiveLobeSegmentation/CIP_InteractiveLobeSegmentation.py
+++ b/Scripted/CIP_InteractiveLobeSegmentation/CIP_InteractiveLobeSegmentation.py
@@ -30,10 +30,6 @@ class CIP_InteractiveLobeSegmentation(ScriptedLoadableModule):
 #
 
 class CIP_InteractiveLobeSegmentationWidget(ScriptedLoadableModuleWidget):
-    @property
-    def moduleName(self):
-        return os.path.basename(__file__).replace(".py", "")    
-    
     def __init__(self, parent=None):
         ScriptedLoadableModuleWidget.__init__(self, parent)
         self.logic = CIP_InteractiveLobeSegmentationLogic()
@@ -789,7 +785,7 @@ class ILSVisualizationWidget(ILSpqWidget):
         """
         self.removeFiducialObservers()
         for fiducialList in list(slicer.util.getNodes('vtkMRMLMarkupsFiducialNode*').values()):
-            tag = fiducialList.AddObserver(fiducialList.MarkupAddedEvent, self.requestNodeAddedUpdate)
+            tag = fiducialList.AddObserver(fiducialList.PointPositionDefinedEvent, self.requestNodeAddedUpdate)
             self.observerTags.append((fiducialList, tag))
 
     def removeFiducialObservers(self):

--- a/Scripted/CIP_PAARatio/CIP_PAARatio.py
+++ b/Scripted/CIP_PAARatio/CIP_PAARatio.py
@@ -39,9 +39,6 @@ class CIP_PAARatioWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-    @property
-    def moduleName(self):
-        return os.path.basename(__file__).replace(".py", "")
 
     @property
     def currentVolumeId(self):

--- a/Scripted/CIP_ParenchymaAnalysis/CIP_ParenchymaAnalysis.py
+++ b/Scripted/CIP_ParenchymaAnalysis/CIP_ParenchymaAnalysis.py
@@ -41,9 +41,6 @@ See <a href=\"$a/Documentation/$b.$c/Modules/ParenchymaAnalysis\">$a/Documentati
 #
 
 class CIP_ParenchymaAnalysisWidget(ScriptedLoadableModuleWidget):
-    @property
-    def moduleName(self):
-        return os.path.basename(__file__).replace(".py", "")
 
     def __init__(self, parent=None):
         ScriptedLoadableModuleWidget.__init__(self, parent)

--- a/Scripted/CIP_ParenchymaSubtypeTraining/CIP_ParenchymaSubtypeTraining.py
+++ b/Scripted/CIP_ParenchymaSubtypeTraining/CIP_ParenchymaSubtypeTraining.py
@@ -45,10 +45,6 @@ class CIP_ParenchymaSubtypeTrainingWidget(CIP_PointsLabellingWidget):
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
-    @property
-    def moduleName(self):
-        return "CIP_ParenchymaSubtypeTraining"
-
     def __init__(self, parent):
         CIP_PointsLabellingWidget.__init__(self, parent)
 
@@ -280,7 +276,7 @@ class CIP_ParenchymaSubtypeTrainingLogic(CIP_PointsLabellingLogic):
         displayNode.SetTextScale(2)
 
         # Add an observer when a new markup is added
-        fidNode.AddObserver(fidNode.MarkupAddedEvent, self.onMarkupAdded)
+        fidNode.AddObserver(fidNode.PointPositionDefinedEvent, self.onMarkupAdded)
 
         return fidNode
 

--- a/Scripted/CIP_ParenchymaSubtypeTrainingLabelling/CIP_ParenchymaSubtypeTrainingLabelling.py
+++ b/Scripted/CIP_ParenchymaSubtypeTrainingLabelling/CIP_ParenchymaSubtypeTrainingLabelling.py
@@ -54,10 +54,6 @@ class CIP_ParenchymaSubtypeTrainingLabellingWidget(ScriptedLoadableModuleWidget)
         self.pendingChangesIdsList = []
 
     @property
-    def moduleName(self):
-        return 'CIP_ParenchymaSubtypeTrainingLabelling'
-
-    @property
     def labelmapNodeNameExtension(self):
         return "parenchymaTrainingLabelMap"
 

--- a/Scripted/CIP_PointsLabelling/CIP_PointsLabelling.py
+++ b/Scripted/CIP_PointsLabelling/CIP_PointsLabelling.py
@@ -35,10 +35,6 @@ class CIP_PointsLabellingWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-    @property
-    def moduleName(self):
-        # TODO: get it from file name
-        return "CIP_PointsLabelling"
 
     def __init__(self, parent):
         ScriptedLoadableModuleWidget.__init__(self, parent)

--- a/Scripted/CIP_RVLVRatio/CIP_RVLVRatio.py
+++ b/Scripted/CIP_RVLVRatio/CIP_RVLVRatio.py
@@ -34,9 +34,6 @@ class CIP_RVLVRatioWidget(ScriptedLoadableModuleWidget):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
     """
-    @property
-    def moduleName(self):
-        return os.path.basename(__file__).replace(".py", "")
 
     @property
     def currentVolumeId(self):


### PR DESCRIPTION
moduleName attribute is set in the widget base class therefore it should not be specified as a property.

MarkupAddedEvent event was renamed to PointPositionDefinedEvent.