### PR TITLE
ENH: Make SlicerCIP compatible with Slicer 5

### DIFF
--- a/Scripted/CIP_/CIP/ui/__init__.py
+++ b/Scripted/CIP_/CIP/ui/__init__.py
@@ -1,5 +1,5 @@
-from .CIP_EditorWidget import CIP_EditorWidget
-from .CIP_EditBox import *
+# from .CIP_EditorWidget import CIP_EditorWidget
+# from .CIP_EditBox import *
 from .CaseReportsWidget import *
 from .PreProcessingWidget import *
 from .MIPViewerWidget import *

--- a/Scripted/CIP_BodyComposition/CIP_BodyComposition.py
+++ b/Scripted/CIP_BodyComposition/CIP_BodyComposition.py
@@ -186,7 +186,7 @@ class CIP_BodyCompositionWidget(ScriptedLoadableModuleWidget):
         self.structuresLayout.addWidget(self.analysisButton, 3, 2)
 
         # Create and embed the Slicer Editor
-        self.__createEditorWidget__()
+        self.__createSegmentEditorWidget__()
 
         # Statistics table
         self.statisticsCollapsibleButton = ctk.ctkCollapsibleButton()
@@ -407,17 +407,22 @@ class CIP_BodyCompositionWidget(ScriptedLoadableModuleWidget):
 
         slicer.app.applicationLogic().PropagateVolumeSelection(0)
 
-    def __createEditorWidget__(self):
+    def __createSegmentEditorWidget__(self):
         """Create and initialize a customize Slicer Editor which contains just some the tools that we need for the segmentation"""
-        self.editorWidget = CIPUI.CIP_EditorWidget(self.parent, False)
+        
+        import qSlicerSegmentationsModuleWidgetsPythonQt
+        self.segmentEditorWidget = qSlicerSegmentationsModuleWidgetsPythonQt.qMRMLSegmentEditorWidget()
+        self.segmentEditorWidget.setMaximumNumberOfUndoStates(10)
+        self.segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+        self.segmentEditorWidget.unorderedEffectsVisible = False
+        self.segmentEditorWidget.setEffectNameOrder(['Paint', 'Draw', 'Erase', 'Threshold', 'Grow from seeds',  'Scissors'])
+        self.layout.addWidget(self.segmentEditorWidget)       
 
-        self.editorWidget.showVolumesFrame = True
-        self.editorWidget.setup()
         # Hide label selector by default
-        self.editorWidget.toolsColor.frame.visible = False
+        #self.editorWidget.toolsColor.frame.visible = False
         # Uncollapse Volumes selector by default
-        self.editorWidget.volumes.collapsed = False
-        self.editorWidget.changePaintEffectRadius(5)
+        #self.editorWidget.volumes.collapsed = False
+        #self.editorWidget.changePaintEffectRadius(5)
 
         # Refresh labelmap info button
         # self.btnRefresh = ctk.ctkPushButton()
@@ -429,15 +434,15 @@ class CIP_BodyCompositionWidget(ScriptedLoadableModuleWidget):
         # self.btnRefresh.setFixedWidth(200)
 
         # Remove structures frame ("Per-Structure Volumes section)
-        self.editorWidget.helper.structuresFrame.visible = False
+        #self.editorWidget.helper.structuresFrame.visible = False
         # self.editorWidget.helper.masterSelectorFrame.layout().addWidget(self.btnRefresh)
         # Remove current listeners for helper box and override them
-        self.editorWidget.helper.masterSelector.disconnect("currentNodeChanged(vtkMRMLNode*)")
+        #self.editorWidget.helper.masterSelector.disconnect("currentNodeChanged(vtkMRMLNode*)")
         # Force to select always a node. It is important to do this at this point, when the events are disconnected,
         # because otherwise the editor would display the color selector (just noisy for the user)
-        self.editorWidget.helper.masterSelector.noneEnabled = False
+        #self.editorWidget.helper.masterSelector.noneEnabled = False
         # Listen to the event when there is a Master Node selected in the HelperBox
-        self.editorWidget.helper.masterSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onMasterNodeSelect)
+        #self.editorWidget.helper.masterSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onMasterNodeSelect)
 
     def __collapseEditorWidget__(self, collapsed=True):
         """Collapse/expand the items in EditorWidget"""

--- a/Scripted/CIP_Calibration/CIP_Calibration.py
+++ b/Scripted/CIP_Calibration/CIP_Calibration.py
@@ -254,8 +254,11 @@ class CIP_CalibrationWidget(ScriptedLoadableModuleWidget,VTKObservationMixin):
         self.segmentEditorWidget.setMRMLSegmentEditorNode(self.segmentEditorNode)
         self.segmentEditorWidget.setMasterVolumeNodeSelectorVisible(False)
         self.segmentEditorWidget.setSegmentationNodeSelectorVisible(False)
+        self.segmentEditorWidget.setSwitchToSegmentationsButtonVisible(False)
+        self.segmentEditorWidget.findChild( 'ctkMenuButton', 'Show3DButton' ).hide()
+        self.segmentEditorWidget.findChild( 'QPushButton', 'AddSegmentButton' ).hide()
+        self.segmentEditorWidget.findChild( 'QPushButton', 'RemoveSegmentButton' ).hide()
         self.segmentEditorWidget.show()
-        #self.segmentEditorWidget.setSwitchToSegmentationsButtonVisible(False)
         self.segmentEditorLayout.addWidget(self.segmentEditorWidget)       
 
     def _onCalibrateButtonClicked_(self):

--- a/Scripted/CIP_ParenchymaSubtypeTrainingLabelling/CIP_ParenchymaSubtypeTrainingLabelling.py
+++ b/Scripted/CIP_ParenchymaSubtypeTrainingLabelling/CIP_ParenchymaSubtypeTrainingLabelling.py
@@ -204,7 +204,7 @@ class CIP_ParenchymaSubtypeTrainingLabellingWidget(ScriptedLoadableModuleWidget)
         self.mainLayout.addWidget(self.saveResultsDirectoryButton, 4, 1, 1, 2)
         self.saveResultsDirectoryButton.connect("directoryChanged (QString)", self._onSaveResultsDirectoryChanged_)
 
-        self._createEditorWidget_()
+        self._createSegmentEditorWidget_()
 
         # MIP viewer (by default it will be hidden)
         self.mipCollapsibleButton = ctk.ctkCollapsibleButton()
@@ -487,29 +487,29 @@ class CIP_ParenchymaSubtypeTrainingLabellingWidget(ScriptedLoadableModuleWidget)
         self.checkMasterAndLabelMapNodes()
 
 
-    def _createEditorWidget_(self):
+
+    def _createSegmentEditorWidget_(self):
         """Create and initialize a customize Slicer Editor which contains just some the tools that we need for the segmentation"""
-        if self.activeEditorTools is None:
-            # We don't want Paint effect by default
-            self.activeEditorTools = (
-                "DefaultTool", "DrawEffect", "PaintEffect", "RectangleEffect", "EraseLabel", "PreviousCheckPoint", "NextCheckPoint")
-
-        self.editorWidget = CIPUI.CIP_EditorWidget(self.parent, showVolumesFrame=True, activeTools=self.activeEditorTools)
-
-        self.editorWidget.setup()
-        self.editorWidget.setThresholds(-50000, 50000)  # Remove thresholds
+        
+        import qSlicerSegmentationsModuleWidgetsPythonQt
+        self.segmentEditorWidget = qSlicerSegmentationsModuleWidgetsPythonQt.qMRMLSegmentEditorWidget()
+        self.segmentEditorWidget.setMaximumNumberOfUndoStates(10)
+        self.segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+        self.segmentEditorWidget.unorderedEffectsVisible = False
+        self.segmentEditorWidget.setEffectNameOrder(['Paint', 'Draw', 'Erase', 'Threshold', 'Grow from seeds',  'Scissors'])
+        self.layout.addWidget(self.segmentEditorWidget)       
 
         # Collapse Volumes selector by default
-        self.editorWidget.volumes.collapsed = True
+        #self.editorWidget.volumes.collapsed = True
 
         # Remove current listeners for helper box and override them
-        self.editorWidget.helper.masterSelector.disconnect("currentNodeChanged(vtkMRMLNode*)")
-        self.editorWidget.helper.mergeSelector.disconnect("currentNodeChanged(vtkMRMLNode*)")
+        #self.editorWidget.helper.masterSelector.disconnect("currentNodeChanged(vtkMRMLNode*)")
+        #self.editorWidget.helper.mergeSelector.disconnect("currentNodeChanged(vtkMRMLNode*)")
         # Force to select always a node. It is important to do this at this point, when the events are disconnected,
         # because otherwise the editor would display the color selector (just noisy for the user)
-        self.editorWidget.helper.masterSelector.noneEnabled = False
+        #self.editorWidget.helper.masterSelector.noneEnabled = False
         # Listen to the event when there is a Master Node selected in the HelperBox
-        self.editorWidget.helper.masterSelector.connect("currentNodeChanged(vtkMRMLNode*)", self._onMasterNodeSelect_)
+        #self.editorWidget.helper.masterSelector.connect("currentNodeChanged(vtkMRMLNode*)", self._onMasterNodeSelect_)
 
     def _collapseEditorWidget_(self, collapsed=True):
         """Collapse/expand the items in EditorWidget"""

--- a/Scripted/CMakeLists.txt
+++ b/Scripted/CMakeLists.txt
@@ -6,7 +6,7 @@ set(modules
   CIP_AVRatio
   CIP_InteractiveLobeSegmentation
   CIP_ParenchymaAnalysis
-  # incompatible with Slicer 5
+  #  incompatible with Slicer 5
   #CIP_BodyComposition
   CIP_CalciumScoring
   CIP_LesionModel

--- a/Scripted/CMakeLists.txt
+++ b/Scripted/CMakeLists.txt
@@ -6,15 +6,16 @@ set(modules
   CIP_AVRatio
   CIP_InteractiveLobeSegmentation
   CIP_ParenchymaAnalysis
-  CIP_BodyComposition
+  # incompatible with Slicer 5
+  #CIP_BodyComposition
   CIP_CalciumScoring
   CIP_LesionModel
   CIP_MIPViewer
   CIP_PAARatio
   CIP_PointsLabelling
-  CIP_ParenchymaSubtypeTraining
-  CIP_TracheaStentPlanning
-  CIP_ParenchymaSubtypeTrainingLabelling
+  #CIP_ParenchymaSubtypeTraining
+  #CIP_TracheaStentPlanning
+  #CIP_ParenchymaSubtypeTrainingLabelling
   CIP_RVLVRatio
   CIP_Calibration
   )
@@ -22,6 +23,5 @@ set(modules
 foreach (module ${modules})
   add_subdirectory(${module})
 endforeach()
-
 
 


### PR DESCRIPTION
SlicerCIP is currently (Jan 2022) throwing extensions when loaded from the extension manager in Slicer 4.13 preview and probably in the upcoming Slicer 5. Most base modules are not showing up as extensions. 

During PW 36 we have improved the SlicerCIP   

*   to load without errors in 4.13
*   to remove currently non-working modules from the menu
*   to rewrite the CIP "Calibration" module removing outdated Slicer technology

This is a work in progress and follow-up PRs are to be expected, in which working modules will possibly be re-added.