### PR TITLE
BUG: Comment out CIP_LesionModel from CMakeLists.txt

### DIFF
--- a/Scripted/CMakeLists.txt
+++ b/Scripted/CMakeLists.txt
@@ -9,7 +9,7 @@ set(modules
   #  incompatible with Slicer 5
   #CIP_BodyComposition
   CIP_CalciumScoring
-  CIP_LesionModel
+  #CIP_LesionModel
   CIP_MIPViewer
   CIP_PAARatio
   CIP_PointsLabelling


### PR DESCRIPTION
- because the module throws multiple exceptions and is not working in Slicer 4.11 and 4.13
- only working modules should be in the CIP menu